### PR TITLE
split up into a docker-compose and docker-compose.dev.yml

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,19 @@
+version: '3.4'
+
+services:
+  frontend:
+    restart: "no"
+  identifier:
+    ports:
+      - "80:80"
+    restart: "no"
+  dispatcher:
+    restart: "no"
+  database:
+    ports:
+      - "8890:8890"
+    restart: "no"
+  resource:
+    restart: "no"
+  query-equivalence:
+    restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,39 +1,52 @@
 version: '3.4'
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "10m"
+    max-file: "3"
 
 services:
   frontend:
     image: redpencil/frontend-sparql-interactive-tutorial
     links:
       - identifier:backend
+    logging: *default-logging
+    restart: always
   identifier:
     image: semtech/mu-identifier:1.9.1
     links:
       - dispatcher:dispatcher
-    ports:
-      - "80:80"
+    logging: *default-logging
+    restart: always
   dispatcher:
     image: semtech/mu-dispatcher:2.0.0
     links:
       - resource:resource
     volumes:
       - ./config/dispatcher:/config
+    logging: *default-logging
+    restart: always
   database:
     image: redpencil/virtuoso:1.0.0
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/application"
-    ports:
-      - "8890:8890"
     volumes:
       - ./data/db:/data
       - ./config/virtuoso/virtuoso.ini:/data/virtuoso.ini
+    logging: *default-logging
+    restart: always
   resource:
     image: semtech/mu-cl-resources:1.20.0
     links:
       - database:database
     volumes:
       - ./config/resources:/config
+    logging: *default-logging
+    restart: always  
   query-equivalence:
     image: redpencil/query-equivalence-service
     links:
       - database:database
+    logging: *default-logging
+    restart: always


### PR DESCRIPTION
include the dev yml for development locally. on a server we just use the docker-compos.yml
also added default logging settings so we don't keep the entire log

FYI I use this in my .bashrc to make this automatic, but you can also set up a .env file locally

```

# sets up compose env
function dev_compose_env() {
    COMPOSE_FILE=''
    if [ -f "$PWD/docker-compose.yml" ]; then
        COMPOSE_FILE='docker-compose.yml'
        if [ -f "$PWD/docker-compose.dev.yml" ];then
            COMPOSE_FILE="$COMPOSE_FILE:docker-compose.dev.yml"
        fi
        if [ -f "$PWD/docker-compose.override.yml" ];then
            COMPOSE_FILE="$COMPOSE_FILE:docker-compose.override.yml"
        fi
        echo "using COMPOSE_FILE=$COMPOSE_FILE"
        export COMPOSE_FILE
    fi
}

function replace_cd() {
    if builtin cd "$@";then
        dev_compose_env
    fi
}

```