### PR TITLE
Fix(sparql): Add `application/n-triples` in sparql `define_accept_types`

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -3,7 +3,7 @@ defmodule Dispatcher do
   define_accept_types [
     html: [ "text/html", "application/xhtml+html" ],
     json: [ "application/json", "application/vnd.api+json" ],
-    sparql: [ "application/sparql-results+json" ]
+    sparql: [ "application/sparql-results+json", "application/n-triples" ]
   ]
 
   @any %{}


### PR DESCRIPTION
## Context 

Some SPARQL calls use `Accept: application/n-triples`, like the following `CONSTRUCT query`
```
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX foaf: <http://xmlns.com/foaf/0.1/>
PREFIX mo: <http://purl.org/ontology/mo/>
CONSTRUCT {
  ?artist mo:collaborated_with ?otherArtist .
}
WHERE {
  ?artist foaf:made ?work .
  ?otherArtist foaf:made ?work . 
}
LIMIT 100
```
Because `application/n-triples` is not listed in `define_accept_types` < `sparql` type, these calls return the error `Status Code: 431 Request Header Fields Too Large`

## Proposal

Add `application/n-triples` in sparql `define_accept_types`

## Before

![image](https://user-images.githubusercontent.com/3050307/229828022-7b6df1b8-3e2e-4458-b281-a1e4c347e0db.png)


## After

![image](https://user-images.githubusercontent.com/3050307/229828965-b440bb68-328f-44a5-bbd8-fcce621ae485.png)
 